### PR TITLE
Fix service lifetime conflicts

### DIFF
--- a/CorpFileHub.Presentation/Program.cs
+++ b/CorpFileHub.Presentation/Program.cs
@@ -42,6 +42,9 @@ builder.Services.AddSignalR();
 builder.Services.AddControllers();
 builder.Services.AddHttpClient();
 
+// Хранилище сессий в памяти
+builder.Services.AddDistributedMemoryCache();
+
 // Настройка сессий
 builder.Services.AddSession(options =>
 {


### PR DESCRIPTION
## Summary
- prevent injecting scoped services directly into background services
- create service scopes within background tasks instead
- add in-memory cache required for session state

## Testing
- `dotnet build CorpFileHub.sln -c Release`
- `dotnet run --project CorpFileHub.Presentation` *(fails: Name or service not known)*

------
https://chatgpt.com/codex/tasks/task_e_688b00b22fe483309923cd2f7277dae1